### PR TITLE
feat: support for Foliant anchors

### DIFF
--- a/lib/validate-internal-links-tools/find-anchors.js
+++ b/lib/validate-internal-links-tools/find-anchors.js
@@ -2,10 +2,14 @@
 
 'use strict'
 const FoliantSlug = require('./foliant-slugger.js')
+const anchorTags = /<anchor>(.*?)<\/anchor>/
 
 const slugs = new FoliantSlug()
 
-const { forEachHeading, addError } = require('markdownlint-rule-helpers')
+const {
+  forEachHeading, addError,
+  filterTokens
+} = require('markdownlint-rule-helpers')
 module.exports = {
   names: ['find-anchors'],
   description: 'Found anchors: ',
@@ -19,5 +23,11 @@ module.exports = {
       addError(onError, heading.lineNumber, ref.toString())
     }
     )
+    filterTokens(params, 'inline', function forToken (token) {
+      if (anchorTags.test(token.line)) {
+        const ref = anchorTags.exec(token.content)['1']
+        addError(onError, token.lineNumber, ref.toString())
+      }
+    })
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdownlint-rules-foliant",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Markdownlint rules for Foliant projects",
   "license": "MIT",
   "homepage": "https://github.com/holamgadol/markdownlint-foliant-rules",

--- a/test/rules.test.js
+++ b/test/rules.test.js
@@ -111,6 +111,7 @@ test('validate-internal-links', async t => {
     ],
     config: {
       default: true,
+      MD033: false,
       MD042: false,
       MD051: false
     },
@@ -119,7 +120,7 @@ test('validate-internal-links', async t => {
   }
   const expectedResult = {
     './test/test-src/topic-A/validate-internal-links.md': {
-      'validate-internal-links': [39, 41, 43, 45, 47, 49, 51, 53, 55, 57, 59, 61, 63, 65, 67, 69, 71, 77, 79, 81]
+      'validate-internal-links': [47, 49, 51, 53, 55, 57, 59, 61, 63, 65, 67, 69, 71, 73, 75, 77, 79, 81, 83, 85, 91, 93, 95]
     }
   }
   const actualResult = await promisify(markdownlint)(options)
@@ -134,6 +135,7 @@ test('validate-internal-links with src', async t => {
     ],
     config: {
       default: true,
+      MD033: false,
       MD042: false,
       MD051: false,
       'validate-internal-links': {
@@ -146,7 +148,7 @@ test('validate-internal-links with src', async t => {
   }
   const expectedResult = {
     './test/test-src/topic-A/validate-internal-links.md': {
-      'validate-internal-links': [39, 41, 43, 45, 47, 49, 51, 53, 55, 57, 59, 61, 63, 65, 69, 71, 77, 79, 81]
+      'validate-internal-links': [47, 49, 51, 53, 55, 57, 59, 61, 63, 65, 67, 69, 71, 73, 77, 79, 81, 83, 85, 91, 93, 95]
     }
   }
   const actualResult = await promisify(markdownlint)(options)
@@ -161,6 +163,7 @@ test('validate-internal-links with src and project', async t => {
     ],
     config: {
       default: true,
+      MD033: false,
       MD042: false,
       MD051: false,
       'validate-internal-links': {
@@ -173,7 +176,7 @@ test('validate-internal-links with src and project', async t => {
   }
   const expectedResult = {
     './test/test-src/topic-A/validate-internal-links.md': {
-      'validate-internal-links': [39, 41, 43, 45, 47, 49, 51, 53, 55, 57, 59, 61, 63, 65, 67, 69, 71, 77, 79]
+      'validate-internal-links': [47, 49, 51, 53, 55, 57, 59, 61, 63, 65, 67, 69, 71, 73, 75, 77, 79, 81, 83, 85, 91, 93]
     }
   }
   const actualResult = await promisify(markdownlint)(options)

--- a/test/test-src/topic-A/validate-internal-links.md
+++ b/test/test-src/topic-A/validate-internal-links.md
@@ -8,6 +8,8 @@ Valid MkDocs link to adjacent [document](../adjacent-document)
 
 Valid classical link to anchor in an adjacent [document](adjacent-document.md#anchor)
 
+**Text for anchor link** <anchor>anchor_link</anchor>
+
 Valid MkDocs link to adjacent [document](../adjacent-document#anchor)
 
 Valid classical link to another [document](../topic-B/topic-B-document.md)
@@ -21,6 +23,12 @@ Valid MkDocs link to anchor in another [document](../../topic-B/topic-B-document
 Valid link to [heading](#valid-links)
 
 Valid classical link to [anchor](#valid)
+
+Valid [anchor link](#anchor_link)
+
+Valid classical link to anchor in another [document](../topic-B/topic-B-document.md#external_anchor_link)
+
+Valid MkDocs link to anchor in another [document](../../topic-B/topic-B-document#external_anchor_link)
 
 Valid MkDoca link to [anchor](./#valid)
 
@@ -69,6 +77,12 @@ Sometimes invalid link to external repo [document](/markdownlint-foliant-rules/t
 Invalid link to [heading](#invalids)
 
 Invalid link to [heading](invalid)
+
+Invalid [anchor link](#anchor_lin)
+
+Invalid classical link to anchor in another [document](../topic-B/topic-B-document.md#external_anchor_lin)
+
+Invalid MkDocs link to anchor in another [document](../../topic-B/topic-B-document#external_anchor_lin)
 
 Empty [link]()
 

--- a/test/test-src/topic-B/topic-B-document.md
+++ b/test/test-src/topic-B/topic-B-document.md
@@ -3,3 +3,5 @@
 ## Introduction {#anchor}
 
 fill text
+
+**Text for anchor link** <anchor>external_anchor_link</anchor>


### PR DESCRIPTION
find-anchors searches anchors in [anchors](https://foliant-docs.github.io/docs/preprocessors/anchors/) syntax