### PR TITLE
Update non-literal-fence-label.js

### DIFF
--- a/lib/non-literal-fence-label.js
+++ b/lib/non-literal-fence-label.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 'use strict'
-const nonLiteral = /[^a-zA-Z0-9_\-\s]+/
+const nonLiteral = /[^a-zA-Z0-9_\-\s\+]+/
 
 const { addError, filterTokens } = require('markdownlint-rule-helpers')
 

--- a/lib/non-literal-fence-label.js
+++ b/lib/non-literal-fence-label.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 'use strict'
-const nonLiteral = /[^a-zA-Z0-9_\-\s\+]+/
+const nonLiteral = /[^a-zA-Z0-9_\-\s+]+/
 
 const { addError, filterTokens } = require('markdownlint-rule-helpers')
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdownlint-rules-foliant",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Markdownlint rules for Foliant projects",
   "license": "MIT",
   "homepage": "https://github.com/holamgadol/markdownlint-foliant-rules",


### PR DESCRIPTION
fixed triggering when using `c++` fence code blocks