### PR TITLE
add: rule for checking includes map

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest]
-        node-version: [14.x, 16.x, 17.x, 18.x, 19.x]
+        node-version: [16.x, 17.x, 18.x, 19.x]
+        include:
+          - os: ubuntu-latest
+            node-version: 14.x
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -242,3 +242,11 @@ npx markdownlint-cli2-fix "src/**/*.md"
 
 Install the [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) extension
 for better interactive linting.
+
+## Tests
+
+To run the tests, run:
+
+```bash
+npx ava
+```

--- a/lib/validate-internal-links-tools/includes_map/analyzer.js
+++ b/lib/validate-internal-links-tools/includes_map/analyzer.js
@@ -1,0 +1,11 @@
+const findAnchorInIncludes = function (filepath, anchor, refSet, map) {
+  for (let i = 0; i < map.length; i++) {
+    if (process.env.PWD + '/' + map[i].file === filepath) {
+      if (map[i].anchors.includes(anchor)) {
+        refSet.add(filepath + '#' + anchor)
+      }
+    }
+  }
+}
+
+module.exports = findAnchorInIncludes

--- a/lib/validate-internal-links-tools/includes_map/analyzer.js
+++ b/lib/validate-internal-links-tools/includes_map/analyzer.js
@@ -4,8 +4,10 @@ const cwd = path.normalize(process.cwd().toString())
 const findAnchorInIncludes = function (filepath, anchor, refSet, map) {
   for (let i = 0; i < map.length; i++) {
     if (path.resolve(cwd, String(map[i].file)) === filepath) {
-      if (map[i].anchors.includes(anchor)) {
-        refSet.add(filepath + '#' + anchor)
+      if (map[i].anchors !== undefined) {
+        if (map[i].anchors.includes(anchor)) {
+          refSet.add(filepath + '#' + anchor)
+        }
       }
     }
   }

--- a/lib/validate-internal-links-tools/includes_map/analyzer.js
+++ b/lib/validate-internal-links-tools/includes_map/analyzer.js
@@ -1,6 +1,9 @@
+const path = require('path')
+const cwd = path.normalize(process.cwd().toString())
+
 const findAnchorInIncludes = function (filepath, anchor, refSet, map) {
   for (let i = 0; i < map.length; i++) {
-    if (process.env.PWD + '/' + map[i].file === filepath) {
+    if (path.resolve(cwd, String(map[i].file)) === filepath) {
       if (map[i].anchors.includes(anchor)) {
         refSet.add(filepath + '#' + anchor)
       }

--- a/lib/validate-internal-links.js
+++ b/lib/validate-internal-links.js
@@ -5,6 +5,7 @@
 const path = require('path')
 const fs = require('fs')
 const findExternalAnchors = require('./validate-internal-links-tools/find-etxrenal-anchors')
+const findAnchorInIncludes = require('./validate-internal-links-tools/includes_map/analyzer')
 const resolvedLink = require('./validate-internal-links-tools/link-resolver')
 const {
   addError,
@@ -41,6 +42,11 @@ module.exports = {
             if (fs.existsSync(file)) {
               if (anchor) {
                 findExternalAnchors(file, refs)
+                const includesMapPath = process.env.PWD + '/includes_map.json'
+                if (fs.existsSync(includesMapPath)) {
+                  const map = require(includesMapPath)
+                  findAnchorInIncludes(file, anchor, refs, map)
+                }
                 if (!refs.has(link)) {
                   addError(onError, token.lineNumber, 'file exists, but invalid anchor', originalLink)
                 }

--- a/lib/validate-internal-links.js
+++ b/lib/validate-internal-links.js
@@ -27,6 +27,7 @@ module.exports = {
     const src = String(params.config.src || './src/')
     const project = params.config.project
     const srcDir = path.resolve(cwd, src)
+    const includesMapPath = path.resolve(cwd, String(params.config.includes_map || './includes_map.json'))
     findExternalAnchors(base, refs)
 
     forEachInlineChild(params, 'link_open', async function forToken (token) {
@@ -42,7 +43,6 @@ module.exports = {
             if (fs.existsSync(file)) {
               if (anchor) {
                 findExternalAnchors(file, refs)
-                const includesMapPath = process.env.PWD + '/includes_map.json'
                 if (fs.existsSync(includesMapPath)) {
                   const map = require(includesMapPath)
                   findAnchorInIncludes(file, anchor, refs, map)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdownlint-rules-foliant",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Markdownlint rules for Foliant projects",
   "license": "MIT",
   "homepage": "https://github.com/holamgadol/markdownlint-foliant-rules",

--- a/test/find-anchor-in-includes-map.test.js
+++ b/test/find-anchor-in-includes-map.test.js
@@ -1,0 +1,32 @@
+const test = require('ava')
+
+const findExternalAnchors = require('../lib/validate-internal-links-tools/find-etxrenal-anchors')
+
+const refs = new Set()
+const testRoot = __dirname
+
+const docPath = '/test-src/find-external-anchors/anchors-source-A.md'
+
+const docAnchors = [
+  testRoot + docPath + '#testAnchor',
+  testRoot + docPath + '#heading-in-another-document'
+].sort()
+
+test('find anchors in doc.md', t => {
+  findExternalAnchors(testRoot + docPath, refs)
+  const items = Array.from(refs).sort()
+  t.deepEqual(items, docAnchors)
+})
+
+const articlePath = '/test-src/find-external-anchors/anchors-source-B.md'
+
+const articleAnchors = [
+  testRoot + articlePath + '#якорь',
+  testRoot + articlePath + '#заголовок-на-русском-языке'
+].sort()
+
+test('find anchors in article.md', t => {
+  findExternalAnchors(testRoot + articlePath, refs)
+  const items = Array.from(refs).sort()
+  t.deepEqual(items, docAnchors.concat(articleAnchors).sort())
+})

--- a/test/find-anchor-in-includes-map.test.js
+++ b/test/find-anchor-in-includes-map.test.js
@@ -1,32 +1,16 @@
 const test = require('ava')
 
-const findExternalAnchors = require('../lib/validate-internal-links-tools/find-etxrenal-anchors')
+const findAnchorInIncludes = require('../lib/validate-internal-links-tools/includes_map/analyzer')
 
 const refs = new Set()
-const testRoot = __dirname
+const file = process.cwd() + '/src/main.md'
+const anchor = 'anchor-in-text'
+const map = [{ file: 'src/main.md', includes: ['src/included-file.md'], anchors: ['anchor-in-text', 'anchor-customid'] }]
 
-const docPath = '/test-src/find-external-anchors/anchors-source-A.md'
+test('find anchors in includes_map.json', t => {
+  const items = new Set()
+  items.add(process.cwd() + '/src/main.md#anchor-in-text')
 
-const docAnchors = [
-  testRoot + docPath + '#testAnchor',
-  testRoot + docPath + '#heading-in-another-document'
-].sort()
-
-test('find anchors in doc.md', t => {
-  findExternalAnchors(testRoot + docPath, refs)
-  const items = Array.from(refs).sort()
-  t.deepEqual(items, docAnchors)
-})
-
-const articlePath = '/test-src/find-external-anchors/anchors-source-B.md'
-
-const articleAnchors = [
-  testRoot + articlePath + '#якорь',
-  testRoot + articlePath + '#заголовок-на-русском-языке'
-].sort()
-
-test('find anchors in article.md', t => {
-  findExternalAnchors(testRoot + articlePath, refs)
-  const items = Array.from(refs).sort()
-  t.deepEqual(items, docAnchors.concat(articleAnchors).sort())
+  findAnchorInIncludes(file, anchor, refs, map)
+  t.deepEqual(refs, items)
 })


### PR DESCRIPTION
Added checking of anchors by the includes map. The includes map must be located at the place where the check is launched

- [x] get includes map path from config
- [x] add test
- [ ] to make a path to the includes map in the configuration from the foliant-md-linter (https://github.com/holamgadol/foliant-md-linter/pull/13)