### PR TITLE
update: validate-internal-links rule

### DIFF
--- a/lib/validate-internal-links.js
+++ b/lib/validate-internal-links.js
@@ -37,6 +37,11 @@ module.exports = {
         const link = resolvedLink(originalLink, base, dir, project, srcDir)
         const file = link.split('#')[0]
         const anchor = link.split('#')[1]
+
+        if (originalLink.includes('#') && originalLink.endsWith('/')) {
+          addError(onError, token.lineNumber, 'trailing slash in anchor', originalLink)
+        }
+
         if (fs.existsSync(includesMapPath)) {
           const map = require(includesMapPath)
           findAnchorInIncludes(workingDir, file, anchor, refs, map)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdownlint-rules-foliant",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Markdownlint rules for Foliant projects",
   "license": "MIT",
   "homepage": "https://github.com/holamgadol/markdownlint-foliant-rules",


### PR DESCRIPTION
- added link checking with a slash after the anchor