### PR TITLE
fix: validate-internal-links errors

### DIFF
--- a/lib/validate-internal-links.js
+++ b/lib/validate-internal-links.js
@@ -38,7 +38,7 @@ module.exports = {
 
     const links = filterByTypes(params.parsers.micromark.tokens, ['link'])
     for (const token of links) {
-      const originalLink = decodeURIComponent(token.text.match(/\(([^)]*)\)/)[1])
+      const originalLink = decodeURIComponent(token.children[1].text.match(/\(([^)]*)\)/)[1].trim().replace(/ ".*"$/, ''))
       if (!urlCheck.test(originalLink) && originalLink !== '') {
         const link = resolvedLink(originalLink, base, dir, project, srcDir)
         const file = link.split('#')[0]
@@ -118,7 +118,7 @@ module.exports = {
 
     const imageTokens = filterByTypes(params.parsers.micromark.tokens, ['image'])
     imageTokens.forEach(token => {
-      const originalLink = decodeURIComponent(token.text.match(/\(([^)]*)\)/)[1])
+      const originalLink = decodeURIComponent(token.children[1].text.match(/\(([^)]*)\)/)[1].trim().replace(/ ".*"$/, ''))
       if (!urlCheck.test(originalLink) && originalLink !== '') {
         const link = resolvedLink(originalLink, base, dir)
         if (!fs.existsSync(link)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdownlint-rules-foliant",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Markdownlint rules for Foliant projects",
   "license": "MIT",
   "homepage": "https://github.com/holamgadol/markdownlint-foliant-rules",


### PR DESCRIPTION
Fix `validate-internal-links` errors caused by:

- using parentheses in the link text,
- using additional parameters for links and images,
- adding spaces at the end of the link.